### PR TITLE
Add getTxOrders method in cowApi

### DIFF
--- a/src/api/cow/index.ts
+++ b/src/api/cow/index.ts
@@ -166,6 +166,24 @@ export class CowApi<T extends ChainId> {
     }
   }
 
+  async getTxOrders(txHash: string): Promise<OrderMetaData[]> {
+    log.debug(`[api:${this.API_NAME}] Get tx orders for `, this.chainId, txHash)
+
+    try {
+      const response = await this.get(`/transactions/${txHash}/orders`)
+
+      if (!response.ok) {
+        const errorResponse: ApiErrorObject = await response.json()
+        throw new OperatorError(errorResponse)
+      } else {
+        return response.json()
+      }
+    } catch (error) {
+      log.error('Error getting transaction orders information:', error)
+      throw new OperatorError(UNHANDLED_ORDER_ERROR)
+    }
+  }
+
   async getOrder(orderId: string): Promise<OrderMetaData | null> {
     log.debug(`[api:${this.API_NAME}] Get order for `, this.chainId, orderId)
     try {

--- a/src/api/cow/index.ts
+++ b/src/api/cow/index.ts
@@ -180,6 +180,7 @@ export class CowApi<T extends ChainId> {
       }
     } catch (error) {
       log.error('Error getting transaction orders information:', error)
+      if (error instanceof OperatorError) throw error
       throw new OperatorError(UNHANDLED_ORDER_ERROR)
     }
   }


### PR DESCRIPTION
Closes #15 

Added `getTxOrders` method in CowApi since It is used by the [explorer](https://github.com/gnosis/gp-ui/blob/develop/src/api/operator/operatorApi.ts#L248)