### PR TITLE
Use provider's chainId as default if present

### DIFF
--- a/src/CowSdk.ts
+++ b/src/CowSdk.ts
@@ -25,6 +25,10 @@ export class CowSdk<T extends ChainId> {
     log.setLevel(options.loglevel || 'error')
   }
 
+  updateChainId = (chainId: T) => {
+    this.context.updateChainId(chainId)
+  }
+
   validateAppDataDocument = validateAppDataDocument
 
   async signOrder(order: Omit<UnsignedOrder, 'appData'>) {

--- a/src/CowSdk.ts
+++ b/src/CowSdk.ts
@@ -1,30 +1,50 @@
+import { Signer } from 'ethers'
+import log, { LogLevelDesc } from 'loglevel'
 import { version as SDK_VERSION } from '../package.json'
 import { CowApi } from './api'
+import { CowError } from './utils/common'
 import { SupportedChainId as ChainId } from '/constants/chains'
 import { validateAppDataDocument } from '/utils/appData'
 import { Context, CowContext } from '/utils/context'
 import { signOrder, signOrderCancellation, UnsignedOrder } from '/utils/sign'
 
+log.setDefaultLevel('debug')
+
+type Options = {
+  loglevel?: LogLevelDesc
+}
+
 export class CowSdk<T extends ChainId> {
   static version = SDK_VERSION
-  chainId: T
   context: Context
-  cowApi: CowApi<T>
+  cowApi: CowApi
 
-  constructor(chainId: T, cowContext: CowContext = {}) {
-    this.chainId = chainId
-    this.context = new Context(cowContext)
-    this.cowApi = new CowApi(chainId, this.context)
+  constructor(chainId: T, cowContext: CowContext = {}, options: Options = {}) {
+    this.context = new Context(chainId, { ...cowContext })
+    this.cowApi = new CowApi(this.context)
+    log.setLevel(options.loglevel || 'error')
   }
 
   validateAppDataDocument = validateAppDataDocument
 
-  signOrder(order: Omit<UnsignedOrder, 'appData'>) {
-    return signOrder({ ...order, appData: this.context.appDataHash }, this.chainId, this.context.signer)
+  async signOrder(order: Omit<UnsignedOrder, 'appData'>) {
+    const signer = this._checkSigner()
+    const chainId = await this.context.chainId
+    return signOrder({ ...order, appData: this.context.appDataHash }, chainId, signer)
   }
 
-  signOrderCancellation(orderId: string) {
-    return signOrderCancellation(orderId, this.chainId, this.context.signer)
+  async signOrderCancellation(orderId: string) {
+    const signer = this._checkSigner()
+    const chainId = await this.context.chainId
+    return signOrderCancellation(orderId, chainId, signer)
+  }
+
+  _checkSigner(signer: Signer | undefined = this.context.signer) {
+    if (!signer) {
+      throw new CowError('No signer available')
+    }
+
+    return signer
   }
 }
 

--- a/src/api/cow/errors/OperatorError.ts
+++ b/src/api/cow/errors/OperatorError.ts
@@ -1,5 +1,5 @@
 import log from 'loglevel'
-import { CowError } from '/utils/common'
+import { CowError, logPrefix } from '/utils/common'
 
 type ApiActionType = 'get' | 'create' | 'delete'
 
@@ -71,6 +71,7 @@ function _mapActionToErrorDetail(action?: ApiActionType) {
       return ApiErrorCodeDetails.UNHANDLED_DELETE_ERROR
     default:
       log.error(
+        logPrefix,
         '[OperatorError::_mapActionToErrorDetails] Uncaught error mapping error action type to server error. Please try again later.'
       )
       return 'Something failed. Please try again later.'
@@ -94,11 +95,11 @@ export default class OperatorError extends CowError {
         // shouldn't fall through as this error constructor expects the error code to exist but just in case
         return errorMessage || orderPostError.errorType
       } else {
-        log.error('Unknown reason for bad order submission', orderPostError)
+        log.error(logPrefix, 'Unknown reason for bad order submission', orderPostError)
         return orderPostError.description
       }
     } catch (error) {
-      log.error('Error handling a 400 error. Likely a problem deserialising the JSON response')
+      log.error(logPrefix, 'Error handling a 400 error. Likely a problem deserialising the JSON response')
       return _mapActionToErrorDetail(action)
     }
   }
@@ -119,6 +120,7 @@ export default class OperatorError extends CowError {
       case 500:
       default:
         log.error(
+          logPrefix,
           `[OperatorError::getErrorFromStatusCode] Error ${
             action === 'create' ? 'creating' : 'cancelling'
           } the order, status code:`,

--- a/src/api/cow/errors/QuoteError.ts
+++ b/src/api/cow/errors/QuoteError.ts
@@ -1,5 +1,5 @@
 import log from 'loglevel'
-import { CowError } from '/utils/common'
+import { CowError, logPrefix } from '/utils/common'
 import { ApiErrorCodes, ApiErrorObject } from './OperatorError'
 
 export interface GpQuoteErrorObject {
@@ -76,11 +76,11 @@ export default class GpQuoteError extends CowError {
         // shouldn't fall through as this error constructor expects the error code to exist but just in case
         return errorMessage || orderPostError.errorType
       } else {
-        log.error('Unknown reason for bad quote fetch', orderPostError)
+        log.error(logPrefix, 'Unknown reason for bad quote fetch', orderPostError)
         return orderPostError.description
       }
     } catch (error) {
-      log.error('Error handling 400/404 error. Likely a problem deserialising the JSON response')
+      log.error(logPrefix, 'Error handling 400/404 error. Likely a problem deserialising the JSON response')
       return GpQuoteError.quoteErrorDetails.UNHANDLED_ERROR
     }
   }
@@ -94,6 +94,7 @@ export default class GpQuoteError extends CowError {
       case 500:
       default:
         log.error(
+          logPrefix,
           '[QuoteError::getErrorFromStatusCode] Error fetching quote, status code:',
           response.status || 'unknown'
         )

--- a/src/api/cow/index.ts
+++ b/src/api/cow/index.ts
@@ -23,7 +23,7 @@ import {
   ProfileData,
   TradeMetaData,
 } from '/api/cow/types'
-import { CowError, objectToQueryString } from '/utils/common'
+import { CowError, logPrefix, objectToQueryString } from '/utils/common'
 import { Context } from '/utils/context'
 
 function getGnosisProtocolUrl(isDev: boolean): Partial<Record<ChainId, string>> {
@@ -77,7 +77,7 @@ async function _handleQuoteResponse<T = any, P extends QuoteQuery = QuoteQuery>(
 
     if (params) {
       const { sellToken, buyToken } = params
-      log.error(`Error querying fee from API - sellToken: ${sellToken}, buyToken: ${buyToken}`)
+      log.error(logPrefix, `Error querying fee from API - sellToken: ${sellToken}, buyToken: ${buyToken}`)
     }
 
     throw quoteError
@@ -109,9 +109,9 @@ export class CowApi {
 
   async getProfileData(address: string): Promise<ProfileData | null> {
     const chainId = await this.context.chainId
-    log.debug(`[api:${this.API_NAME}] Get profile data for`, chainId, address)
+    log.debug(logPrefix, `[api:${this.API_NAME}] Get profile data for`, chainId, address)
     if (chainId !== ChainId.MAINNET) {
-      log.info('Profile data is only available for mainnet')
+      log.info(logPrefix, 'Profile data is only available for mainnet')
       return null
     }
 
@@ -119,7 +119,7 @@ export class CowApi {
 
     if (!response.ok) {
       const errorResponse = await response.json()
-      log.error(errorResponse)
+      log.error(logPrefix, errorResponse)
       throw new CowError(errorResponse?.description)
     } else {
       return response.json()
@@ -130,7 +130,7 @@ export class CowApi {
     const { owner, limit, offset } = params
     const qsParams = objectToQueryString({ owner, limit, offset })
     const chainId = await this.context.chainId
-    log.debug('[util:operator] Get trades for', chainId, owner, { limit, offset })
+    log.debug(logPrefix, '[util:operator] Get trades for', chainId, owner, { limit, offset })
     try {
       const response = await this.get(`/trades${qsParams}`)
 
@@ -141,7 +141,7 @@ export class CowApi {
         return response.json()
       }
     } catch (error) {
-      log.error('Error getting trades:', error)
+      log.error(logPrefix, 'Error getting trades:', error)
       throw new CowError('Error getting trades: ' + error)
     }
   }
@@ -150,7 +150,7 @@ export class CowApi {
     const { owner, limit = 1000, offset = 0 } = params
     const queryString = objectToQueryString({ limit, offset })
     const chainId = await this.context.chainId
-    log.debug(`[api:${this.API_NAME}] Get orders for `, chainId, owner, limit, offset)
+    log.debug(logPrefix, `[api:${this.API_NAME}] Get orders for `, chainId, owner, limit, offset)
 
     try {
       const response = await this.get(`/account/${owner}/orders/${queryString}`)
@@ -162,14 +162,14 @@ export class CowApi {
         return response.json()
       }
     } catch (error) {
-      log.error('Error getting orders information:', error)
+      log.error(logPrefix, 'Error getting orders information:', error)
       throw new OperatorError(UNHANDLED_ORDER_ERROR)
     }
   }
 
   async getOrder(orderId: string): Promise<OrderMetaData | null> {
     const chainId = await this.context.chainId
-    log.debug(`[api:${this.API_NAME}] Get order for `, chainId, orderId)
+    log.debug(logPrefix, `[api:${this.API_NAME}] Get order for `, chainId, orderId)
     try {
       const response = await this.get(`/orders/${orderId}`)
 
@@ -180,7 +180,7 @@ export class CowApi {
         return response.json()
       }
     } catch (error) {
-      log.error('Error getting order information:', error)
+      log.error(logPrefix, 'Error getting order information:', error)
       throw new OperatorError(UNHANDLED_ORDER_ERROR)
     }
   }
@@ -188,12 +188,12 @@ export class CowApi {
   async getPriceQuoteLegacy(params: PriceQuoteParams): Promise<PriceInformation | null> {
     const { baseToken, quoteToken, amount, kind } = params
     const chainId = await this.context.chainId
-    log.debug(`[api:${this.API_NAME}] Get price from API`, params, 'for', chainId)
+    log.debug(logPrefix, `[api:${this.API_NAME}] Get price from API`, params, 'for', chainId)
 
     const response = await this.get(
       `/markets/${toErc20Address(baseToken, chainId)}-${toErc20Address(quoteToken, chainId)}/${kind}/${amount}`
     ).catch((error) => {
-      log.error('Error getting price quote:', error)
+      log.error(logPrefix, 'Error getting price quote:', error)
       throw new QuoteError(UNHANDLED_QUOTE_ERROR)
     })
 
@@ -211,7 +211,7 @@ export class CowApi {
   async sendSignedOrderCancellation(params: OrderCancellationParams): Promise<void> {
     const { cancellation, owner: from } = params
     const chainId = await this.context.chainId
-    log.debug(`[api:${this.API_NAME}] Delete signed order for network`, chainId, cancellation)
+    log.debug(logPrefix, `[api:${this.API_NAME}] Delete signed order for network`, chainId, cancellation)
 
     const response = await this.delete(`/orders/${cancellation.orderUid}`, {
       signature: cancellation.signature,
@@ -225,14 +225,14 @@ export class CowApi {
       throw new CowError(errorMessage)
     }
 
-    log.debug(`[api:${this.API_NAME}] Cancelled order`, cancellation.orderUid, chainId)
+    log.debug(logPrefix, `[api:${this.API_NAME}] Cancelled order`, cancellation.orderUid, chainId)
   }
 
   async sendOrder(params: { order: Omit<OrderCreation, 'appData'>; owner: string }): Promise<OrderID> {
     const fullOrder: OrderCreation = { ...params.order, appData: this.context.appDataHash }
     const chainId = await this.context.chainId
     const { owner } = params
-    log.debug(`[api:${this.API_NAME}] Post signed order for network`, chainId, fullOrder)
+    log.debug(logPrefix, `[api:${this.API_NAME}] Post signed order for network`, chainId, fullOrder)
 
     // Call API
     const response = await this.post(`/orders`, {
@@ -249,7 +249,7 @@ export class CowApi {
     }
 
     const uid = (await response.json()) as string
-    log.debug(`[api:${this.API_NAME}] Success posting the signed order`, uid)
+    log.debug(logPrefix, `[api:${this.API_NAME}] Success posting the signed order`, uid)
     return uid
   }
 

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -1,3 +1,5 @@
+import { version as SDK_VERSION } from '../../package.json'
+
 export class CowError extends Error {
   error_code?: string
 
@@ -25,3 +27,5 @@ export function objectToQueryString(o: any): string {
 
   return qsResult ? `?${qsResult}` : ''
 }
+
+export const logPrefix = `cow-sdk (${SDK_VERSION}):`

--- a/src/utils/context.ts
+++ b/src/utils/context.ts
@@ -1,6 +1,6 @@
 import { Signer } from 'ethers'
 import log from 'loglevel'
-import { CowError } from './common'
+import { CowError, logPrefix } from './common'
 import { DEFAULT_APP_DATA_HASH } from '/constants'
 import { SupportedChainId as ChainId } from '/constants/chains'
 
@@ -43,7 +43,7 @@ export class Context implements Partial<CowContext> {
       return Promise.resolve(this.#chainId)
     }
 
-    log.debug('Getting chainId from provider')
+    log.debug(logPrefix, 'Getting chainId from provider')
 
     const getAndReconciliateNetwork = async () => {
       const network = await provider.getNetwork()
@@ -51,6 +51,7 @@ export class Context implements Partial<CowContext> {
 
       if (chainId !== this.#chainId) {
         log.debug(
+          logPrefix,
           `ChainId mismatch: Provider's chainId: ${chainId} vs Context's chainId: ${
             this.#chainId
           }. Updating Context's chainId`

--- a/src/utils/context.ts
+++ b/src/utils/context.ts
@@ -33,6 +33,8 @@ export class Context implements Partial<CowContext> {
       throw new CowError(`Invalid chainId: ${chainId}`)
     }
 
+    log.debug(logPrefix, `Updating chainId to: ${chainId}`)
+
     this.#chainId = chainId
     return chainId
   }

--- a/src/utils/sign.ts
+++ b/src/utils/sign.ts
@@ -15,7 +15,7 @@ import log from 'loglevel'
 import { SupportedChainId as ChainId } from '/constants/chains'
 import { GP_SETTLEMENT_CONTRACT_ADDRESS } from '/constants'
 import { TypedDataDomain, Signer } from '@ethersproject/abstract-signer'
-import { CowError } from './common'
+import { CowError, logPrefix } from './common'
 
 // For error codes, see:
 // - https://eth.wiki/json-rpc/json-rpc-error-codes-improvement-proposal
@@ -151,7 +151,7 @@ async function _signPayload(
         _signer = signer
     }
   } catch (e) {
-    log.error('Wallet not supported:', e)
+    log.error(logPrefix, 'Wallet not supported:', e)
     throw new CowError('Wallet not supported')
   }
 
@@ -160,7 +160,7 @@ async function _signPayload(
   } catch (e) {
     if (!isProviderRpcError(e)) {
       // Some other error signing. Let it bubble up.
-      log.error(e)
+      log.error(logPrefix, e)
       throw e
     }
 


### PR DESCRIPTION
Close #12 

This improves how the chainId was handled due to the possibility of a mismatch between the chainId used in the constructor to instantiate  the sdk and the provider's chainId:

```js
// before
const provider = new ethers.providers.Web3Provider(window.ethereum, "any") // network is Mainnet
const chainId = 4;
const cowSdk = new CowSdk(chainId, { signer: provider.getSigner() })
// this will use Rinkeby as the chainId
```

```js
// now
const provider = new ethers.providers.Web3Provider(window.ethereum, "any") // network is Mainnet
const chainId = 4;
const cowSdk = new CowSdk(chainId, { signer: provider.getSigner() })
// this will use Mainnet as the chainId
```

You can still instantiate the sdk without passing any signer just for querying purposes and also update the current chainId
```js
const chainId = 1;
const cowSdk = new CowSdk(chainId)
const quoteResponse = await cowSdk.cowApi.getQuote({...}) // will query Mainnet
cowSdk.updateChainId(4)
const quoteResponse = await cowSdk.cowApi.getQuote({...}) // will query Rinkeby
```

The chainId getter/setter was moved to the Context and made it async.